### PR TITLE
Fixed params for Windows Server 2016 TP5

### DIFF
--- a/NewNanoServerImage.ps1
+++ b/NewNanoServerImage.ps1
@@ -42,7 +42,9 @@ Param(
     [switch]$AddCloudbaseInit = $true,
     [switch]$AddMaaSHooks,
     [string]$CloudbaseInitZipPath,
-    [string]$CloudbaseInitCOMPort = "COM1"
+    [string]$CloudbaseInitCOMPort = "COM1",
+    [Parameter(Mandatory=$False)]
+    [string]$ServerEdition = "Standard" # ["Standard" | "Datacenter"]
 )
 
 $ErrorActionPreference = "Stop"
@@ -86,17 +88,22 @@ else
 $addGuestDrivers = (@("Hyper-V", "KVM", "VMware") -contains $Platform)
 $addOEMDrivers = (@("Hyper-V", "KVM", "VMware") -notcontains $Platform)
 
+$deploymentType = "Host"
+if ($addGuestDrivers) {
+   $deploymentType = "Guest"
+}
+
 $isoMountDrive = (Mount-DiskImage $IsoPath -PassThru | Get-Volume).DriveLetter
 $isoNanoServerPath = "${isoMountDrive}:\NanoServer"
 
 try
 {
-    Import-Module "${isoNanoServerPath}\NanoServerImageGenerator.psm1"
+    Import-Module "${isoNanoServerPath}\NanoServerImageGenerator\NanoServerImageGenerator.psm1"
     New-NanoServerImage -MediaPath "${isoMountDrive}:\" -BasePath $NanoServerDir `
     -MaxSize $MaxSize -AdministratorPassword $AdministratorPassword -TargetPath $vhdPath `
-    -GuestDrivers:$addGuestDrivers -OEMDrivers:$addOEMDrivers `
-    -ReverseForwarders -Compute:$Compute -Storage:$Storage -Clustering:$Clustering `
-    -Containers:$Containers -Packages $Packages
+    -DeploymentType $DeploymentType -OEMDrivers:$addOEMDrivers `
+    -Compute:$Compute -Storage:$Storage -Clustering:$Clustering `
+    -Containers:$Containers -Packages $Packages -Edition $ServerEdition
 }
 finally
 {


### PR DESCRIPTION
Nano server image generator had breaking changes in TP5.  These changes include:
1. We have removed -GuestDrivers. You now need to use -DeploymentType and pass either Guest or Host, based on if you want to deploy the image to a VM or on physical host. 
2. We have added -Edition mandatory parameter and you need to specify if you want to use Standard or Datacenter flavor of Nano Server. 
3. We have remove -ReverseForwarders. They are now enabled by default. 
4. We have renamed -MergePath to -CopyFiles. It now supports an array of values. 
5. We have moved the module from \NanoServer to \NanoServer\NanoServerImageGenerator. 
6. We have removed a dependency on having Hyper-V role installed. 
7. We have added automatic dependency detection for packages, so that installation order no longer matters. 
8. We have added option to produce WIM media. 
9. We have added options to specify static DNS servers using -Ipv6Dns and -Ipv4Dns. 
10. We have added option to specify an array of commands to be executed after setup is complete using -SetupCompleteCommands. 
11. We have added an option to create media to boot from ramdisk: -RamdiskBoot. 
12. We have added -Development option to allow you to install unsigned drivers, copy debugger binaries, open a port for debugging, enable test signing and enable installation of AppX packages without developer license. 
13. We have added Get-NanoServerPackage cmdlet to list all available packages. 
14. We have added -ServicingPackages to allow you to install any KB packages using full path. 
15. We have added -UnattendPath to allow using any custom unattend file. We have also moved -AdministratorPassword to the offlineServicing so both password and computer name can be reset offline. 
16. If you do not specify ComputerName, we will autogenerate one for you (only when not attempting to join a domain). 
17. We have removed the requirement to specify the source media/target image language. 

Note: By merging this pull request this will no longer work with Windows Server 2016 TP4.  If backwards compat is needed then we'll need to add some extra logic.
