### PR TITLE
Do not use a COM port when generating Nano image

### DIFF
--- a/NewNanoServerImage.ps1
+++ b/NewNanoServerImage.ps1
@@ -207,10 +207,15 @@ if($ExtraDriversPaths -or $featuresToEnable -or $AddMaaSHooks -or $AddCloudbaseI
                 $d = mkdir $setupScriptsDir
             }
 
+            if ($CloudbaseInitCOMPort) {
+                Write-Warning ("Cloudbase-Init logging COM Port cannot be set to $CloudbaseInitCOMPort," + `
+		               " as Nano Server does not support serial ports.")
+            }
+
             . "${PSScriptRoot}\CloudbaseInitOfflineSetup.ps1" -CloudbaseInitBaseDir $cloudbaseInitBaseDir `
             -CloudbaseInitRuntimeBaseDir $cloudbaseInitRuntimeBaseDir `
             -CloudbaseInitZipPath $zipPath `
-            -LoggingCOMPort $CloudbaseInitCOMPort
+            -LoggingCOMPort $null
 
             copy -Force (Join-Path $PSScriptRoot "SetupComplete.cmd") $setupScriptsDir
             copy -Force (Join-Path $PSScriptRoot "PostInstall.ps1") $setupScriptsDir


### PR DESCRIPTION
On Windows Nano Server, COM (serial) ports are not supported, thus
we do not need to set cloudbase-init to log on the serial port.